### PR TITLE
chore(ci): fix download artifacts 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,8 +149,8 @@ jobs:
           name: dist-windows-amd64
           path: raybot-${{ env.VERSION }}-windows-amd64.zip
 
-  build-docker:
-    name: Build Docker image
+  build-and-push-docker-image:
+    name: Build and push Docker image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -183,6 +183,8 @@ jobs:
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
+        with:
+          name: dist-*
       - name: Draft Release
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
- Changed job name from `build-docker` to `build-and-push-docker-image` for clarity.
- Updated artifact download step to use a wildcard for better flexibility.