### PR TITLE
refactor: rewrite serial `Read` method and add unit test

### DIFF
--- a/internal/hardware/espserial/README.md
+++ b/internal/hardware/espserial/README.md
@@ -1,0 +1,16 @@
+### ✅ `Client.Read()` Test Cases
+
+| #   | Input (mock serial data)           | Expected Output                           |
+|-----|------------------------------------|-------------------------------------------|
+| 1   | `>data\r\n`                        | `data`                    
+| 2   | `>>\rdata\r\n`                     | `>\rdata`                    
+| 3   | `>data\x00\r\n`                    | `data\x00`               
+| 4   | `>>data\x00\r\n`                   | `>data\x00`          
+| 5   | `>>data\x00\r\n\r\n`               | `>data\x00`      
+| 6   | `random>message here\r\ngarbage`   | `message here`             
+| 7   | `>null\r\n\x00\x00`                | `null`                    
+| 7   | `>\r\n`                            | ``          
+| 8   | *(no port connected)*              | `ErrESPSerialNotConnected` 
+| 9   | `>data without end`                | EOF               
+| 10  | `data only`                        | EOF                
+| 11  | *(context cancelled)*              | Context cancelled      

--- a/internal/hardware/espserial/client.go
+++ b/internal/hardware/espserial/client.go
@@ -1,7 +1,6 @@
 package espserial
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"sync"
@@ -21,7 +20,7 @@ type Client interface {
 	Close() error
 	Connected() bool
 	Write(ctx context.Context, data []byte) error
-	Read() ([]byte, error)
+	Read(ctx context.Context) ([]byte, error)
 }
 
 type DefaultClient struct {
@@ -115,51 +114,52 @@ func (c *DefaultClient) Write(ctx context.Context, data []byte) error {
 }
 
 // Read reads data from the serial port.
-func (c *DefaultClient) Read() ([]byte, error) {
+func (c *DefaultClient) Read(ctx context.Context) ([]byte, error) {
 	if c.port == nil {
 		return nil, ErrESPSerialNotConnected
 	}
 
-	return c.read()
+	return c.read(ctx)
 }
 
 // read continuously reads from the port until a complete message is received.
 // A complete message starts with '>' and ends with CR LF (\r\n).
 // The message is returned without the prefix and suffix
-func (c *DefaultClient) read() ([]byte, error) {
-	var res []byte
-	messageStarted := false
+func (c *DefaultClient) read(ctx context.Context) ([]byte, error) {
+	var msg []byte
+	isMsgStarted := false
 
 	for {
-		buf := make([]byte, readBufferSize)
-		n, err := c.port.Read(buf)
-		if err != nil {
-			return nil, err
-		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
 
-		// Only append the bytes that were actually read
-		chunk := buf[:n]
-
-		// If we haven't found the start marker yet, look for it
-		if !messageStarted {
-			startIdx := bytes.IndexByte(chunk, '>')
-			if startIdx >= 0 {
-				// Found the start marker, only append from that point
-				res = append(res, chunk[startIdx:]...)
-				messageStarted = true
+		default:
+			buf := make([]byte, readBufferSize)
+			n, err := c.port.Read(buf)
+			if err != nil {
+				return nil, err
 			}
-		} else {
-			// Already found start marker, append the whole chunk
-			res = append(res, chunk...)
-		}
 
-		// Check if we have a complete message
-		if messageStarted && len(res) > 0 && res[0] == '>' && bytes.HasSuffix(res, []byte("\r\n")) {
-			// Remove the prefix and suffix
-			res = res[1 : len(res)-2]
-			// Remove null bytes
-			res = bytes.Trim(res, "\x00")
-			return res, nil
+			chunk := buf[:n]
+
+			for _, b := range chunk {
+				if !isMsgStarted {
+					if b == '>' {
+						isMsgStarted = true
+					}
+					continue
+				}
+
+				msg = append(msg, b)
+				msgLength := len(msg)
+
+				// check end marker
+				if msgLength >= 2 && msg[msgLength-2] == '\r' && msg[msgLength-1] == '\n' {
+					msg = msg[:msgLength-2] // remove \r\n
+					return msg, nil
+				}
+			}
 		}
 	}
 }

--- a/internal/hardware/espserial/client_test.go
+++ b/internal/hardware/espserial/client_test.go
@@ -1,0 +1,203 @@
+package espserial
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tbe-team/raybot/internal/config"
+)
+
+func TestClientWrite(t *testing.T) {
+	t.Run("Should write successfully", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		data := []byte(`{"cmd":"test"}`)
+		err := client.Write(context.Background(), data)
+
+		assert.NoError(t, err)
+
+		// Check the written bytes
+		expected := append([]byte(">"), data...)
+		expected = append(expected, '\r', '\n')
+		assert.Equal(t, expected, mockPort.WriteBuffer.Bytes())
+	})
+
+	t.Run("Should return error when not connected", func(t *testing.T) {
+		client := NewClient(config.Serial{})
+		client.port = nil
+
+		data := []byte(`{"cmd":"test"}`)
+		err := client.Write(context.Background(), data)
+
+		assert.Error(t, err)
+		assert.Equal(t, ErrESPSerialNotConnected, err)
+	})
+
+	t.Run("Should return context cancelled error", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel the context immediately
+
+		data := []byte(`{"cmd":"test"}`)
+		err := client.Write(ctx, data)
+
+		assert.Error(t, err)
+		assert.Equal(t, context.Canceled, err)
+	})
+}
+
+func TestClientRead(t *testing.T) {
+	t.Run("Should return simple data successfully", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		mockPort.ReadBuffer.Write([]byte(">data\r\n"))
+
+		res, err := client.Read(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("data"), res)
+	})
+
+	t.Run("Should return double start markers", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		mockPort.ReadBuffer.Write([]byte(">>data\r\n"))
+
+		res, err := client.Read(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, []byte(">data"), res)
+	})
+
+	t.Run("Should return null bytes in data", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		mockPort.ReadBuffer.Write([]byte(">data\x00\r\n"))
+
+		res, err := client.Read(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("data\x00"), res)
+	})
+
+	t.Run("Should return start marker in data", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		mockPort.ReadBuffer.Write([]byte(">>data\x00\r\n"))
+
+		res, err := client.Read(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, []byte(">data\x00"), res)
+	})
+
+	t.Run("Should return multiple line endings", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		mockPort.ReadBuffer.Write([]byte(">>data\x00\r\n\r\n"))
+
+		res, err := client.Read(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, []byte(">data\x00"), res)
+	})
+
+	t.Run("Should return random prefix", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		mockPort.ReadBuffer.Write([]byte("random>message here\r\ngarbage"))
+
+		res, err := client.Read(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("message here"), res)
+	})
+
+	t.Run("Should return null bytes after message", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		mockPort.ReadBuffer.Write([]byte(">null\r\n\x00\x00"))
+
+		res, err := client.Read(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("null"), res)
+	})
+
+	t.Run("Should return empty message", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		mockPort.ReadBuffer.Write([]byte(">\r\n"))
+
+		res, err := client.Read(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, []byte(""), res)
+	})
+
+	t.Run("Should return not connected error", func(t *testing.T) {
+		client := NewClient(config.Serial{})
+		client.port = nil
+
+		res, err := client.Read(context.Background())
+		assert.Error(t, err)
+		assert.Equal(t, ErrESPSerialNotConnected, err)
+		assert.Nil(t, res)
+	})
+
+	t.Run("Should return EOF error on missing end marker", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		mockPort.ReadBuffer.Write([]byte(">data without end"))
+
+		res, err := client.Read(context.Background())
+		assert.Error(t, err)
+		assert.Equal(t, io.EOF, err)
+		assert.Nil(t, res)
+	})
+
+	t.Run("Should return EOF error on missing start marker", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		mockPort.ReadBuffer.Write([]byte("data only"))
+
+		res, err := client.Read(context.Background())
+		assert.Error(t, err)
+		assert.Equal(t, io.EOF, err)
+		assert.Nil(t, res)
+	})
+
+	t.Run("Should return context cancelled error", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		res, err := client.Read(ctx)
+		assert.Error(t, err)
+		assert.Equal(t, context.Canceled, err)
+		assert.Nil(t, res)
+	})
+}

--- a/internal/hardware/espserial/controller_test.go
+++ b/internal/hardware/espserial/controller_test.go
@@ -1,0 +1,72 @@
+package espserial
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tbe-team/raybot/internal/config"
+)
+
+func TestController(t *testing.T) {
+	t.Run("Open cargo door successfully", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		err := client.OpenCargoDoor(context.Background(), 10)
+		assert.NoError(t, err)
+
+		actual := overrideIDAndRemoveMarkers(t, mockPort.WriteBuffer.Bytes(), "abc")
+		expected := `
+		{
+			"id":"abc",
+			"type":0,
+			"data":{
+				"state":1,
+				"speed":10,
+				"enable":1
+			}
+		}`
+		assert.JSONEq(t, expected, string(actual))
+	})
+
+	t.Run("Close cargo door successfully", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		err := client.CloseCargoDoor(context.Background(), 10)
+		assert.NoError(t, err)
+
+		actual := overrideIDAndRemoveMarkers(t, mockPort.WriteBuffer.Bytes(), "abc")
+		expected := `
+		{
+			"id":"abc",
+			"type":0,
+			"data":{
+				"state":0,
+				"speed":10,
+				"enable":1
+			}
+		}`
+		assert.JSONEq(t, expected, string(actual))
+	})
+}
+
+// overrideIDAndRemoveMarkers overrides the id of the command, and remove the markers
+func overrideIDAndRemoveMarkers(t *testing.T, data []byte, id string) []byte {
+	b := data[1 : len(data)-2] // remove > and \r\n
+
+	var m map[string]any
+	err := json.Unmarshal(b, &m)
+	assert.NoError(t, err)
+	m["id"] = id
+
+	b, err = json.Marshal(m)
+	assert.NoError(t, err)
+
+	return b
+}

--- a/internal/hardware/espserial/mock_serial_port.go
+++ b/internal/hardware/espserial/mock_serial_port.go
@@ -1,0 +1,79 @@
+package espserial
+
+import (
+	"bytes"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"go.bug.st/serial"
+)
+
+var _ serial.Port = (*FakeSerialPort)(nil)
+
+type FakeSerialPort struct {
+	mock.Mock
+	ReadBuffer  bytes.Buffer
+	WriteBuffer bytes.Buffer
+}
+
+func (m *FakeSerialPort) SetMode(mode *serial.Mode) error {
+	args := m.Called(mode)
+	return args.Error(0)
+}
+
+func (m *FakeSerialPort) Read(p []byte) (int, error) {
+	return m.ReadBuffer.Read(p)
+}
+
+func (m *FakeSerialPort) Write(p []byte) (int, error) {
+	n, err := m.WriteBuffer.Write(p)
+	return n, err
+}
+
+func (m *FakeSerialPort) Drain() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *FakeSerialPort) ResetInputBuffer() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *FakeSerialPort) ResetOutputBuffer() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *FakeSerialPort) SetDTR(dtr bool) error {
+	args := m.Called(dtr)
+	return args.Error(0)
+}
+
+func (m *FakeSerialPort) SetRTS(rts bool) error {
+	args := m.Called(rts)
+	return args.Error(0)
+}
+
+func (m *FakeSerialPort) GetModemStatusBits() (*serial.ModemStatusBits, error) {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*serial.ModemStatusBits), args.Error(1)
+}
+
+func (m *FakeSerialPort) SetReadTimeout(t time.Duration) error {
+	args := m.Called(t)
+	return args.Error(0)
+}
+
+func (m *FakeSerialPort) Close() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *FakeSerialPort) Break(d time.Duration) error {
+	args := m.Called(d)
+	return args.Error(0)
+}

--- a/internal/hardware/picserial/client_test.go
+++ b/internal/hardware/picserial/client_test.go
@@ -1,0 +1,203 @@
+package picserial
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tbe-team/raybot/internal/config"
+)
+
+func TestClientWrite(t *testing.T) {
+	t.Run("Should write successfully", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		data := []byte(`{"cmd":"test"}`)
+		err := client.Write(context.Background(), data)
+
+		assert.NoError(t, err)
+
+		// Check the written bytes
+		expected := append([]byte(">"), data...)
+		expected = append(expected, '\r', '\n')
+		assert.Equal(t, expected, mockPort.WriteBuffer.Bytes())
+	})
+
+	t.Run("Should return error when not connected", func(t *testing.T) {
+		client := NewClient(config.Serial{})
+		client.port = nil
+
+		data := []byte(`{"cmd":"test"}`)
+		err := client.Write(context.Background(), data)
+
+		assert.Error(t, err)
+		assert.Equal(t, ErrPICSerialNotConnected, err)
+	})
+
+	t.Run("Should return context cancelled error", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel the context immediately
+
+		data := []byte(`{"cmd":"test"}`)
+		err := client.Write(ctx, data)
+
+		assert.Error(t, err)
+		assert.Equal(t, context.Canceled, err)
+	})
+}
+
+func TestClientRead(t *testing.T) {
+	t.Run("Should return simple data successfully", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		mockPort.ReadBuffer.Write([]byte(">data\r\n"))
+
+		res, err := client.Read(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("data"), res)
+	})
+
+	t.Run("Should return double start markers", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		mockPort.ReadBuffer.Write([]byte(">>data\r\n"))
+
+		res, err := client.Read(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, []byte(">data"), res)
+	})
+
+	t.Run("Should return null bytes in data", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		mockPort.ReadBuffer.Write([]byte(">data\x00\r\n"))
+
+		res, err := client.Read(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("data\x00"), res)
+	})
+
+	t.Run("Should return start marker in data", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		mockPort.ReadBuffer.Write([]byte(">>data\x00\r\n"))
+
+		res, err := client.Read(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, []byte(">data\x00"), res)
+	})
+
+	t.Run("Should return multiple line endings", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		mockPort.ReadBuffer.Write([]byte(">>data\x00\r\n\r\n"))
+
+		res, err := client.Read(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, []byte(">data\x00"), res)
+	})
+
+	t.Run("Should return random prefix", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		mockPort.ReadBuffer.Write([]byte("random>message here\r\ngarbage"))
+
+		res, err := client.Read(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("message here"), res)
+	})
+
+	t.Run("Should return null bytes after message", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		mockPort.ReadBuffer.Write([]byte(">null\r\n\x00\x00"))
+
+		res, err := client.Read(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("null"), res)
+	})
+
+	t.Run("Should return empty message", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		mockPort.ReadBuffer.Write([]byte(">\r\n"))
+
+		res, err := client.Read(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, []byte(""), res)
+	})
+
+	t.Run("Should return not connected error", func(t *testing.T) {
+		client := NewClient(config.Serial{})
+		client.port = nil
+
+		res, err := client.Read(context.Background())
+		assert.Error(t, err)
+		assert.Equal(t, ErrPICSerialNotConnected, err)
+		assert.Nil(t, res)
+	})
+
+	t.Run("Should return EOF error on missing end marker", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		mockPort.ReadBuffer.Write([]byte(">data without end"))
+
+		res, err := client.Read(context.Background())
+		assert.Error(t, err)
+		assert.Equal(t, io.EOF, err)
+		assert.Nil(t, res)
+	})
+
+	t.Run("Should return EOF error on missing start marker", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		mockPort.ReadBuffer.Write([]byte("data only"))
+
+		res, err := client.Read(context.Background())
+		assert.Error(t, err)
+		assert.Equal(t, io.EOF, err)
+		assert.Nil(t, res)
+	})
+
+	t.Run("Should return context cancelled error", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		res, err := client.Read(ctx)
+		assert.Error(t, err)
+		assert.Equal(t, context.Canceled, err)
+		assert.Nil(t, res)
+	})
+}

--- a/internal/hardware/picserial/controller_test.go
+++ b/internal/hardware/picserial/controller_test.go
@@ -1,0 +1,157 @@
+package picserial
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tbe-team/raybot/internal/config"
+)
+
+func TestController(t *testing.T) {
+	t.Run("Set cargo position successfully", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		err := client.SetCargoPosition(context.Background(), 10)
+		assert.NoError(t, err)
+
+		actual := overrideIDAndRemoveMarkers(t, mockPort.WriteBuffer.Bytes(), "abc")
+		expected := `
+		{
+			"id":"abc",
+			"type":2,
+			"data":{
+				"target_position":10,
+				"enable":1
+			}
+		}`
+		assert.JSONEq(t, expected, string(actual))
+	})
+
+	t.Run("Move forward successfully", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		err := client.MoveForward(context.Background(), 10)
+		assert.NoError(t, err)
+
+		actual := overrideIDAndRemoveMarkers(t, mockPort.WriteBuffer.Bytes(), "abc")
+		expected := `
+		{
+			"id":"abc",
+			"type":3,
+			"data":{
+				"direction":0,
+				"speed":10,
+				"enable":1
+			}
+		}`
+		assert.JSONEq(t, expected, string(actual))
+	})
+
+	t.Run("Move backward successfully", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		err := client.MoveBackward(context.Background(), 10)
+		assert.NoError(t, err)
+
+		actual := overrideIDAndRemoveMarkers(t, mockPort.WriteBuffer.Bytes(), "abc")
+		expected := `
+		{
+			"id":"abc",
+			"type":3,
+			"data":{
+				"direction":1,
+				"speed":10,
+				"enable":1
+			}
+		}`
+		assert.JSONEq(t, expected, string(actual))
+	})
+
+	t.Run("Stop drive motor successfully", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		err := client.StopDriveMotor(context.Background())
+		assert.NoError(t, err)
+
+		actual := overrideIDAndRemoveMarkers(t, mockPort.WriteBuffer.Bytes(), "abc")
+		expected := `
+		{
+			"id":"abc",
+			"type":3,
+			"data":{
+				"direction":0,
+				"speed":0,
+				"enable":0
+			}
+		}`
+		assert.JSONEq(t, expected, string(actual))
+	})
+
+	t.Run("Config battery charge successfully", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		err := client.ConfigBatteryCharge(context.Background(), 10, true)
+		assert.NoError(t, err)
+
+		actual := overrideIDAndRemoveMarkers(t, mockPort.WriteBuffer.Bytes(), "abc")
+		expected := `
+		{
+			"id":"abc",
+			"type":0,
+			"data":{
+				"current_limit":10,
+				"enable":1
+			}
+		}`
+		assert.JSONEq(t, expected, string(actual))
+	})
+
+	t.Run("Config battery discharge successfully", func(t *testing.T) {
+		mockPort := &FakeSerialPort{}
+		client := NewClient(config.Serial{})
+		client.port = mockPort
+
+		err := client.ConfigBatteryDischarge(context.Background(), 10, true)
+		assert.NoError(t, err)
+
+		actual := overrideIDAndRemoveMarkers(t, mockPort.WriteBuffer.Bytes(), "abc")
+		expected := `
+		{
+			"id":"abc",
+			"type":1,
+			"data":{
+				"current_limit":10,
+				"enable":1
+			}
+		}`
+		assert.JSONEq(t, expected, string(actual))
+	})
+}
+
+// overrideIDAndRemoveMarkers overrides the id of the command, and remove the markers
+func overrideIDAndRemoveMarkers(t *testing.T, data []byte, id string) []byte {
+	b := data[1 : len(data)-2] // remove > and \r\n
+
+	var m map[string]any
+	err := json.Unmarshal(b, &m)
+	assert.NoError(t, err)
+	m["id"] = id
+
+	b, err = json.Marshal(m)
+	assert.NoError(t, err)
+
+	return b
+}

--- a/internal/hardware/picserial/mock_serial_port.go
+++ b/internal/hardware/picserial/mock_serial_port.go
@@ -1,0 +1,79 @@
+package picserial
+
+import (
+	"bytes"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"go.bug.st/serial"
+)
+
+var _ serial.Port = (*FakeSerialPort)(nil)
+
+type FakeSerialPort struct {
+	mock.Mock
+	ReadBuffer  bytes.Buffer
+	WriteBuffer bytes.Buffer
+}
+
+func (m *FakeSerialPort) SetMode(mode *serial.Mode) error {
+	args := m.Called(mode)
+	return args.Error(0)
+}
+
+func (m *FakeSerialPort) Read(p []byte) (int, error) {
+	return m.ReadBuffer.Read(p)
+}
+
+func (m *FakeSerialPort) Write(p []byte) (int, error) {
+	n, err := m.WriteBuffer.Write(p)
+	return n, err
+}
+
+func (m *FakeSerialPort) Drain() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *FakeSerialPort) ResetInputBuffer() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *FakeSerialPort) ResetOutputBuffer() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *FakeSerialPort) SetDTR(dtr bool) error {
+	args := m.Called(dtr)
+	return args.Error(0)
+}
+
+func (m *FakeSerialPort) SetRTS(rts bool) error {
+	args := m.Called(rts)
+	return args.Error(0)
+}
+
+func (m *FakeSerialPort) GetModemStatusBits() (*serial.ModemStatusBits, error) {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*serial.ModemStatusBits), args.Error(1)
+}
+
+func (m *FakeSerialPort) SetReadTimeout(t time.Duration) error {
+	args := m.Called(t)
+	return args.Error(0)
+}
+
+func (m *FakeSerialPort) Close() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *FakeSerialPort) Break(d time.Duration) error {
+	args := m.Called(d)
+	return args.Error(0)
+}


### PR DESCRIPTION
- Modified `Read` methods in `espserial` and `picserial` clients to accept a context parameter for better control over read operations.
- Added unit tests for `Read` and `Write` methods in both `espserial` and `picserial` clients, ensuring comprehensive coverage of various scenarios.
- Added unit tests for both espserial and picserial `Controller`