### PR TITLE
fix: emergency stop call and current command state should be CANCELED

### DIFF
--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -200,7 +200,6 @@ func New(configFilePath, dbPath string) (*Application, CleanupFunc, error) {
 	appStateService := appstateimpl.NewService(appStateRepository)
 	peripheralService := peripheralimpl.NewService()
 
-	commandProcessingLock := processinglockimpl.New()
 	commandService := commandimpl.NewService(
 		cfg.Cron.DeleteOldCommand,
 		log,
@@ -208,7 +207,7 @@ func New(configFilePath, dbPath string) (*Application, CleanupFunc, error) {
 		eventBus,
 		commandRepository,
 		appStateRepository,
-		commandProcessingLock,
+		processinglockimpl.New(),
 		executor.NewRouter(
 			cfg.Cargo,
 			log,
@@ -226,7 +225,6 @@ func New(configFilePath, dbPath string) (*Application, CleanupFunc, error) {
 
 	apperrorcodeService := apperrorcodeimpl.NewService()
 	emergencyService := emergencyimpl.NewService(
-		commandProcessingLock,
 		commandService,
 		driveMotorService,
 		liftMotorService,

--- a/internal/services/command/command.go
+++ b/internal/services/command/command.go
@@ -49,6 +49,13 @@ type Service interface {
 	// CancelActiveCloudCommands cancels all QUEUED and PROCESSING commands created by the cloud.
 	CancelActiveCloudCommands(ctx context.Context) error
 
+	// LockProcessingCommand locks the processing command.
+	// It also cancels the current processing command.
+	LockProcessingCommand(ctx context.Context) error
+
+	// UnlockProcessingCommand unlocks the processing command.
+	UnlockProcessingCommand(ctx context.Context) error
+
 	ExecuteCreatedCommand(ctx context.Context, params ExecuteCreatedCommandParams) error
 
 	DeleteCommandByID(ctx context.Context, params DeleteCommandByIDParams) error

--- a/internal/services/command/commandimpl/service.go
+++ b/internal/services/command/commandimpl/service.go
@@ -134,6 +134,26 @@ func (s *Service) CancelActiveCloudCommands(ctx context.Context) error {
 	return nil
 }
 
+func (s *Service) LockProcessingCommand(ctx context.Context) error {
+	if err := s.processingLock.Lock(); err != nil {
+		return fmt.Errorf("lock processing command: %w", err)
+	}
+
+	if err := s.CancelCurrentProcessingCommand(ctx); err != nil {
+		return fmt.Errorf("cancel current processing command: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Service) UnlockProcessingCommand(_ context.Context) error {
+	if err := s.processingLock.Unlock(); err != nil {
+		return fmt.Errorf("unlock processing command: %w", err)
+	}
+
+	return nil
+}
+
 func (s *Service) ExecuteCreatedCommand(ctx context.Context, params command.ExecuteCreatedCommandParams) error {
 	cmd, err := s.commandRepository.GetCommandByID(ctx, params.CommandID)
 	if err != nil {

--- a/internal/services/command/commandimpl/service.go
+++ b/internal/services/command/commandimpl/service.go
@@ -140,7 +140,9 @@ func (s *Service) LockProcessingCommand(ctx context.Context) error {
 	}
 
 	if err := s.CancelCurrentProcessingCommand(ctx); err != nil {
-		return fmt.Errorf("cancel current processing command: %w", err)
+		if !errors.Is(err, command.ErrNoCommandBeingProcessed) {
+			return fmt.Errorf("cancel current processing command: %w", err)
+		}
 	}
 
 	return nil
@@ -171,18 +173,6 @@ func (s *Service) ExecuteCreatedCommand(ctx context.Context, params command.Exec
 	if processingExists {
 		s.log.Info("command in PROCESSING status already exists, this command will be queued")
 		return nil
-	}
-
-	cmd, err = s.commandRepository.UpdateCommand(ctx, command.UpdateCommandParams{
-		ID:           cmd.ID,
-		Status:       command.StatusProcessing,
-		SetStatus:    true,
-		StartedAt:    ptr.New(time.Now()),
-		SetStartedAt: true,
-		UpdatedAt:    time.Now(),
-	})
-	if err != nil {
-		return fmt.Errorf("update command: %w", err)
 	}
 
 	s.executeCommand(ctx, cmd)
@@ -219,7 +209,21 @@ func (s *Service) runNextExecutableCommand(ctx context.Context) {
 		return
 	}
 
+	s.log.Info("found executable command, executing", slog.Any("command", cmd))
+	s.executeCommand(ctx, cmd)
+}
+
+func (s *Service) executeCommand(ctx context.Context, cmd command.Command) {
+	if err := s.processingLock.WaitUntilUnlocked(ctx); err != nil {
+		// if the context is canceled, we don't need to run the next executable command
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+		s.log.Error("failed to wait for processing lock to be unlocked", slog.Any("error", err))
+	}
+
 	if cmd.Status == command.StatusQueued {
+		var err error
 		cmd, err = s.commandRepository.UpdateCommand(ctx, command.UpdateCommandParams{
 			ID:           cmd.ID,
 			Status:       command.StatusProcessing,
@@ -232,19 +236,6 @@ func (s *Service) runNextExecutableCommand(ctx context.Context) {
 			s.log.Error("failed to update command to PROCESSING status", slog.Any("error", err))
 			return
 		}
-	}
-
-	s.log.Info("found executable command, executing", slog.Any("command", cmd))
-	s.executeCommand(ctx, cmd)
-}
-
-func (s *Service) executeCommand(ctx context.Context, cmd command.Command) {
-	if err := s.processingLock.WaitUntilUnlocked(ctx); err != nil {
-		// if the context is canceled, we don't need to run the next executable command
-		if errors.Is(err, context.Canceled) {
-			return
-		}
-		s.log.Error("failed to wait for processing lock to be unlocked", slog.Any("error", err))
 	}
 
 	runningCmd := newRunningCommand(cmd)

--- a/internal/services/command/mocks/service.gen.go
+++ b/internal/services/command/mocks/service.gen.go
@@ -484,6 +484,98 @@ func (_c *FakeService_ListCommands_Call) RunAndReturn(run func(context.Context, 
 	return _c
 }
 
+// LockProcessingCommand provides a mock function with given fields: ctx
+func (_m *FakeService) LockProcessingCommand(ctx context.Context) error {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for LockProcessingCommand")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// FakeService_LockProcessingCommand_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LockProcessingCommand'
+type FakeService_LockProcessingCommand_Call struct {
+	*mock.Call
+}
+
+// LockProcessingCommand is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *FakeService_Expecter) LockProcessingCommand(ctx interface{}) *FakeService_LockProcessingCommand_Call {
+	return &FakeService_LockProcessingCommand_Call{Call: _e.mock.On("LockProcessingCommand", ctx)}
+}
+
+func (_c *FakeService_LockProcessingCommand_Call) Run(run func(ctx context.Context)) *FakeService_LockProcessingCommand_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *FakeService_LockProcessingCommand_Call) Return(_a0 error) *FakeService_LockProcessingCommand_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *FakeService_LockProcessingCommand_Call) RunAndReturn(run func(context.Context) error) *FakeService_LockProcessingCommand_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UnlockProcessingCommand provides a mock function with given fields: ctx
+func (_m *FakeService) UnlockProcessingCommand(ctx context.Context) error {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UnlockProcessingCommand")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// FakeService_UnlockProcessingCommand_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UnlockProcessingCommand'
+type FakeService_UnlockProcessingCommand_Call struct {
+	*mock.Call
+}
+
+// UnlockProcessingCommand is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *FakeService_Expecter) UnlockProcessingCommand(ctx interface{}) *FakeService_UnlockProcessingCommand_Call {
+	return &FakeService_UnlockProcessingCommand_Call{Call: _e.mock.On("UnlockProcessingCommand", ctx)}
+}
+
+func (_c *FakeService_UnlockProcessingCommand_Call) Run(run func(ctx context.Context)) *FakeService_UnlockProcessingCommand_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *FakeService_UnlockProcessingCommand_Call) Return(_a0 error) *FakeService_UnlockProcessingCommand_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *FakeService_UnlockProcessingCommand_Call) RunAndReturn(run func(context.Context) error) *FakeService_UnlockProcessingCommand_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewFakeService creates a new instance of FakeService. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewFakeService(t interface {

--- a/internal/services/command/processinglockimpl/processing_lock_test.go
+++ b/internal/services/command/processinglockimpl/processing_lock_test.go
@@ -62,19 +62,19 @@ func TestProcessingLock(t *testing.T) {
 		wg.Add(10)
 		for range 10 {
 			go func() {
-				wg.Done()
+				defer wg.Done()
 				err := l.WaitUntilUnlocked(context.Background())
 				assert.NoError(t, err)
 				counter.Add(1)
 			}()
 		}
 
-		wg.Wait()
-
 		err := l.WithLock(func() error {
 			return nil
 		})
 		assert.NoError(t, err)
+
+		wg.Wait()
 
 		assert.Equal(t, 10, int(counter.Load()))
 	})


### PR DESCRIPTION
- Introduced LockProcessingCommand and UnlockProcessingCommand methods in the command service interface.
- Implemented the methods in the service implementation to handle command processing locks.
- Updated the emergency service to utilize the new locking methods during operation stop and resume.
- Enhanced mock service to support the new locking functionality in tests.